### PR TITLE
Removed seperate environment configuration for staging

### DIFF
--- a/blueprints/s3-deploy-config/files/config/deploy.js
+++ b/blueprints/s3-deploy-config/files/config/deploy.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 
 module.exports = function(deployTarget) {
+  var isProductionLike = ['staging', 'production'].indexOf(deployTarget) > -1;
   var ENV = {
     build: {},
     pipeline: {
@@ -16,8 +17,8 @@ module.exports = function(deployTarget) {
     }
   };
 
-  if (deployTarget === 'staging') {
-    ENV.build.environment = 'staging';
+  if (isProductionLike) {
+    ENV.build.environment = 'production';
     ENV.s3.accessKeyId = process.env.ASSETS_STAGING_AWS_KEY;
     ENV.s3.secretAccessKey = process.env.ASSETS_STAGING_AWS_SECRET;
     ENV.s3.bucket = process.env.ASSETS_STAGING_BUCKET;
@@ -26,18 +27,6 @@ module.exports = function(deployTarget) {
     ENV["s3-index"].secretAccessKey = process.env.INDEX_STAGING_AWS_SECRET;
     ENV["s3-index"].bucket = process.env.INDEX_STAGING_BUCKET;
     ENV["s3-index"].region = process.env.INDEX_STAGING_REGION;
-  }
-
-  if (deployTarget === 'production') {
-    ENV.build.environment = 'production';
-    ENV.s3.accessKeyId = process.env.ASSETS_PRODUCTION_AWS_KEY;
-    ENV.s3.secretAccessKey = process.env.ASSETS_PRODUCTION_AWS_SECRET;
-    ENV.s3.bucket = process.env.ASSETS_PRODUCTION_BUCKET;
-    ENV.s3.region = process.env.ASSETS_PRODUCTION_REGION;
-    ENV["s3-index"].accessKeyId = process.env.INDEX_PRODUCTION_AWS_KEY;
-    ENV["s3-index"].secretAccessKey = process.env.INDEX_PRODUCTION_AWS_SECRET;
-    ENV["s3-index"].bucket = process.env.INDEX_PRODUCTION_BUCKET;
-    ENV["s3-index"].region = process.env.INDEX_PRODUCTION_REGION;
   }
 
   // Note: if you need to build some configuration asynchronously, you can return

--- a/blueprints/s3-deploy-config/files/config/deploy.js
+++ b/blueprints/s3-deploy-config/files/config/deploy.js
@@ -1,7 +1,6 @@
 /* jshint node: true */
 
 module.exports = function(deployTarget) {
-  var isProductionLike = ['staging', 'production'].indexOf(deployTarget) > -1;
   var ENV = {
     build: {},
     pipeline: {
@@ -17,7 +16,7 @@ module.exports = function(deployTarget) {
     }
   };
 
-  if (isProductionLike) {
+  if (deployTarget === 'staging') {
     ENV.build.environment = 'production';
     ENV.s3.accessKeyId = process.env.ASSETS_STAGING_AWS_KEY;
     ENV.s3.secretAccessKey = process.env.ASSETS_STAGING_AWS_SECRET;
@@ -27,6 +26,18 @@ module.exports = function(deployTarget) {
     ENV["s3-index"].secretAccessKey = process.env.INDEX_STAGING_AWS_SECRET;
     ENV["s3-index"].bucket = process.env.INDEX_STAGING_BUCKET;
     ENV["s3-index"].region = process.env.INDEX_STAGING_REGION;
+  }
+
+  if (deployTarget === 'production') {
+    ENV.build.environment = 'production';
+    ENV.s3.accessKeyId = process.env.ASSETS_PRODUCTION_AWS_KEY;
+    ENV.s3.secretAccessKey = process.env.ASSETS_PRODUCTION_AWS_SECRET;
+    ENV.s3.bucket = process.env.ASSETS_PRODUCTION_BUCKET;
+    ENV.s3.region = process.env.ASSETS_PRODUCTION_REGION;
+    ENV["s3-index"].accessKeyId = process.env.INDEX_PRODUCTION_AWS_KEY;
+    ENV["s3-index"].secretAccessKey = process.env.INDEX_PRODUCTION_AWS_SECRET;
+    ENV["s3-index"].bucket = process.env.INDEX_PRODUCTION_BUCKET;
+    ENV["s3-index"].region = process.env.INDEX_PRODUCTION_REGION;
   }
 
   // Note: if you need to build some configuration asynchronously, you can return


### PR DESCRIPTION
Removed seperate environment configuration for staging because it is not one of the 3 environments officially supported by ember-cli. The deploy.js blueprint now uses an isProductionLike check to determine if the deploy target is a production build or not.
