### PR TITLE
Bump ember-cli-deploy-revision-data to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-deploy-display-revisions": "~0.2.1",
     "ember-cli-deploy-gzip": "~0.2.1",
     "ember-cli-deploy-manifest": "~0.1.1",
-    "ember-cli-deploy-revision-data": "~0.2.3",
+    "ember-cli-deploy-revision-data": "~0.3.1",
     "ember-cli-deploy-s3": "~0.3.0",
     "ember-cli-deploy-s3-index": "~0.4.0"
   },


### PR DESCRIPTION
`ember-cli-deploy-revision-data@0.3.1` fix the fails with the new version of `git-repo-info@1.3`.

See https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/issues/39