### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "broccoli-asset-rev": "^2.2.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.3.0",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
@@ -44,14 +45,13 @@
     "ember-cli-deploy-plugin-pack"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
-    "ember-cli-deploy-build": "~0.1.1",
-    "ember-cli-deploy-display-revisions": "~0.2.1",
-    "ember-cli-deploy-gzip": "~0.2.1",
-    "ember-cli-deploy-manifest": "~0.1.1",
-    "ember-cli-deploy-revision-data": "~0.3.1",
-    "ember-cli-deploy-s3": "^1.0.0-beta.0",
-    "ember-cli-deploy-s3-index": "^1.0.0-beta.1"
+    "ember-cli-deploy-build": "^1.1.0",
+    "ember-cli-deploy-display-revisions": "^1.0.0",
+    "ember-cli-deploy-gzip": "^1.0.0",
+    "ember-cli-deploy-manifest": "^1.1.0",
+    "ember-cli-deploy-revision-data": "^1.0.0",
+    "ember-cli-deploy-s3": "^1.1.0",
+    "ember-cli-deploy-s3-index": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Upgrade all dependencies to `1.x` and move `ember-cli-babel` into `devDependencies`.