### PR TITLE
Moved ember-cli-babel from `devDependencies` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-deploy-build": "^1.1.0",
     "ember-cli-deploy-display-revisions": "^1.0.0",
     "ember-cli-deploy-gzip": "^1.0.0",
@@ -33,7 +34,6 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.1.4",
-    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",


### PR DESCRIPTION
Moved ember-cli-babel from `devDependencies` to `dependencies`. fixes #11

tested by pointing my app to local version. Please merge and release.